### PR TITLE
Delete build cache to fix new pages not showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Documentation for the ZZ Speedsolving Method",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && rm -rf .next/cache",
     "start": "next start"
   },
   "repository": {


### PR DESCRIPTION
When we add new pages and deploy, those new pages aren't being shown in the left nav because of Next.js build cache.
This is an issue with Next/Nextra, so the current workaround is to [delete the cache right after building.](https://github.com/orgs/vercel/discussions/2079#discussioncomment-6606285)